### PR TITLE
adding intro to setting up OIDC

### DIFF
--- a/Development/v4.x/backend/configuration_oidc.md
+++ b/Development/v4.x/backend/configuration_oidc.md
@@ -27,7 +27,7 @@ The `frontend.config.json` requires the following variables to be set to work wi
 ```
 SciCat requires you to specify the `accesstokenprefix` in order to find the the token in the OAuth response. 
 
-The OIDC mechanism assues that you are returning to 127.0.0.1:3000, if your requiret to return to a different address or port you need to edid the `lbBaseURL`  variable. 
+`lbBaseURL` configures the base URL that the SciCat frontend-to-backend (API) service that the frontend will communicate with. It will therefore match the roots of the `OIDC_CALLBACK_URL` and the `OIDC_SUCCESS_URL` in the backend OIDC configurations.
 
 In the `oAuth2Endpoints` include the display text you want to see on the Login button and the suffix of the authURL which is `api/v3/auth/oidc` (the preffix is set as the `lbBaseURL`).
 

--- a/Development/v4.x/backend/configuration_oidc.md
+++ b/Development/v4.x/backend/configuration_oidc.md
@@ -1,169 +1,33 @@
 # OIDC Integration
-SciCat can integrate with one or more OIDC servers to provide Authentication. Integration requires configuration of both backend and frontend in order to setup the redirecting and handshaking that the OAuth2 code flow requires. Additionally, it may involve writing [custom code hooks](#backend-code-hooks)  in the backend in order to properly handle profile information obtained by the OIDC Auth Provider.
+SciCat can integrate with one or more OIDC servers to provide Authentication. Integration requires configuration of both backend and frontend in order to setup the redirecting and handshaking that the OAuth2 code flow requires. Additionally, it may involve writing [custom code hooks](#backend-code-hooks)  in the backend in order to properly handle profile information obtained by the OIDC Auth Provider if you are using a specialised provider.
 
 ## Backend Configuration
-Configuration of the backend for OIDC involves adding a provider to `providers.json` file. See [Start Here](./StartHere.md) for more information on configuring this file.
 
-Here is an example of a provider that uses Google as an authenticator. Google is used here because it is well-documented and commonly available.
-
-```json
-    "google": {
-        "provider": "oidc",
-        "authScheme": "openid connect",
-        "module": "passport-openidconnect",
-        "authPath": "/auth/google",
-        "successRedirect": "http://localhost/user",
-        "failureRedirect": "http://localhost/login",
-        "failureFlash": true,
-        "session": false,
-        "issuer": "https://accounts.google.com",
-        "authorizationURL": "https://accounts.google.com/o/oauth2/v2/auth",
-        "tokenURL": "https://oauth2.googleapis.com/token",
-        "userInfoURL": "https://openidconnect.googleapis.com/v1/userinfo",
-        "clientID": "...",
-        "clientSecret": "...",
-        "callbackURL": "http://localhost:3000/auth/google/callback",
-        "scope": ["email", "profile", "openid"],
-        "loginCallback": "sampleLoginCallback"
-    }
+The backend configuration requires the following to be set as environmental variables in order to work with OIDC.
 ```
-> Note that information about Google sign in can be found [here](https://developers.google.com/identity/protocols/oauth2/openid-connect), details are beyond the scope of this document.
-
-
-> Note that OIDC authentication services publish their specific settings in a Discovery document.. To find the settings for, say, google, see <https://accounts.google.com/.well-known/openid-configuration>.
-
-Details about the fields in this provider configuration:
-* **provider** is used by the loopback-passport-configurator to build a strategy
-* **authScheme** is used by the loopback-passport-configurator to build a strategy
-* **module** describes the passport module to use. passport-openidconnect is already included in the backend
-* **authPath** is the path that the backend will create (with the help of loopback-passport-configurator) to begin the authentication process. The backend will redirect users to this path (once it is configured, of course!)
-* **successRedirect** is the URL passed to the OIDC provider instructing it to redirect the user on success. Here we set it to the a development environment's user page.
-* **failureRedirect** is the URL passed to the OIDC provider instructing it to redirect the user on failed authentication. Here we set it to the a development environment's user page login page.
-* **failureFlash** is currently unsupported.
-* **session** is not needed, since the frontend authenticates outside of sessions.
-* **authorizationURL** is specific to your OIDC provider
-* **tokenURL** is specific to your OIDC provider
-* **userInfoURL** is specific to your OIDC provider
-* **clientID** is specific to your OIDC provider
-* **clientSecret** is specific to your OIDC provider
-* **scope** is specific to your OIDC provider
-* **loginCallback** optional name of a [callback](#configure-callback) function to run to add profile information to the UserIdentity
-
-#### Session Secret 
-The nodejs module `passport-openidconnect` requires the use of the `express-session` module
-to create a login session for the user.
- This requires a _session secret_ to be configured in `config.local.js`:
- ```
- module.exports = {
-  expressSessionSecret: "thisIsSuperSecretForUserSession"
- ```
-
-## SciCat Frontend Configuration 
-
-The default login page in the frontend provides a username/password form that is used both for local and LDAP/AD authentication. When using and OIDC authentication provider, SciCat will not ask the user for credential directly. Instead, the user will be redirected to the OIDC provider to authenticate. So, the frontend provides two configuration settings to modify the login page appropriately.
-
-These setting are accomplished by modifying the frontend [environment document](./Environment.md). 
-
-```javascript
-  
-  loginFormEnabled: false,
-  oAuth2Endpoints: [
-    {displayText: "Google", displayImage: "../../../assets/images/btn_google_light_normal_ios.svg", authURL: "auth/google"}]
-
+OIDC_ISSUER = https://oidc-issuer-address.org # the URL of your OIDC issuer
+OIDC_CLIENT_ID = myClient # The client you use to access it
+OIDC_CLIENT_SECRET = mySciCatSecret # the secret belonging to the client
+OIDC_CALLBACK_URL = https://scicat.myinstitute.org/api/v3/auth/oidc/callback  # the callback url, the root is your scicat url with the suffix api/v3/auth/oidc/callback
+OIDC_SCOPE = email profile openid # the scopes from your oidc provider that are required by SciCat
+OIDC_SUCCESS_URL = https://scicat.myinstitute.org/login # the success URL is your scicat url with the suffix login 
 ```
 
+## Frontend Configuration
 
-* **loginFormEnabled** sets whether to display the username/password form in the login page
-* **oAuth2Endpoints** provides information that the frontend uses to display "Sign in with ..." buttons. Note that this is an array, multiple buttons for multiple OIDC providers can be configured.
-  * **displayText** sets the name of the provider to display in the button. In this case, the button will show "Sign In With Google"
-  * **displayImage** defines an image to display in the button. The image will end up being 24px tall. It is recommended that the image be in SVG format.
-  * **authURL** defines the relative path that the user will be redirected to when they click the button. Note that this maps to the `authPath` setting described above.
-
-## Backend Code Hooks
-
-Configuring backend and frontend to authenticate through OIDC is very useful for providing a third party authentication. However, there two issues that come up that can be addressed with backend code hooks:
-
-* By default, the system will authenticate all users who pass come in through the OAuth Provider. 
-* By default, the users profile in the application will contain information gathered from the OAuth Provider, and nothing more.
-
-### Prevent Authenticating Unkown Users
-
-In [Backend Configuration](#backend-configuration), we configured the loginCallback. The value of this file is the name of a function that must be defined and exported. See [login-call.js](https://github.com/SciCatProject/backend/blob/develop/server/boot/login-callbacks.js) for details.
-
-Code snippet is presented for as an example, omitting the particular details about communicating with an external system:
-
-```javascript
-
-module.exports.sampleLoginCallback = function(req, done) {
-  return function(err, user, identity, token) {
-
-    var authInfo = {
-      identity: identity,
-    };
-    if (token) {
-      authInfo.accessToken = token;
-    }
-
-    const requestURL = getUserURL(identity);
-    if (!requestURL){
-      logger.logError(`unexpected authenticator type: ${identity.provider}`);
-      done();
-      return;
-    }
-    request(requestURL, function (error, response, body) {
-      // ask external system for the user's profile information
-      if (error){
-        // and error occurred talking to the external system (possibly from a connection issue)...deny login
-        logger.logError(`error talking to external ${error.message}`);
-        done(err, null, null);
-        return;
-      }
-      if (response.statusCode == 200) {
-        const bodyObj = JSON.parse(body);
-        logger.logInfo("user service returned", bodyObj);
-      }
-      else{
-        logger.logError(`external system replied with an error ${response.statusCode} - ${body}.`);
-        // external system replied with a negative response...deny login
-        done(err, null, null);
-        return;
-      }
-      //accept login
-      done(err, user, authInfo);
-    });
-  };
-};
+The `frontend.config.json` requires the following variables to be set to work with OIDC.
 ```
-### Add information to User's Profile 
+ 
+      "accessTokenPrefix": "Bearer ", # make sure there is a whitespce between Bearer and the end quotes
+      "lbBaseURL": "https://scicat.myinstitute.org" # the address you are returning to after authentication if it is not 127.0.0.1:3000
+      "oAuth2Endpoints": [
+       {"displayText": "My Institute SSO", "authURL": "api/v3/auth/oidc"}
+      ]
 
-By default profile information from the Authentication Provider will be added to the user's profile. This profile is stored in the DaCat database `UserIdentity` collection. This collection is created by the loopback-component-passport library, and is also used for LDAP authentication. The backend LDAP integrations populate this collection with the user's LDAP profile information automatically with a callback. One of the most important things that is added to the profile is the user's accessGroups field, which is critical to calculating a user's privilege in SciCat.
-
-One way to mimic this with an OAuth2 provider is to use a `before save` [Loopback Operation Hook](https://loopback.io/doc/en/lb3/Operation-hooks.html). This hook will get called as the user logs in and allows you to add information to the `UserIdentity` collection, which will be used in a variety of places, including access controls.
-
-The following code snippet is presented for as an example, omitting the particular details about communicating with an external system:
-
-```javascript
-// Observe saving UserIdentity. This gives us the ability to update the user profile with facility-specific groups
-module.exports = function (app) {
-  app.models.UserIdentity.observe("before save", function(ctx, next) {
-    if (!ctx.data){
-      logger.logInfo("No context data from UserIdentity");
-      next();
-      return;
-    }
-    request(userURL, function (error, response, _body) {
-      // ask external system for user information so we can get group info
-      if (error){
-        logger.logError(`error talking to external system ${error.message}`);
-        next();
-        return;
-      }
-      if (response.statusCode == 200){
-        // add groups to profile, saving in the UserIdentity model
-        ctx.data.profile.accessGroups = JSON.parse(response.body).groups;
-      }
-      next();
-    });
-  });
-};
 ```
+SciCat requires you to specify the `accesstokenprefix` in order to find the the token in the OAuth response. 
+
+The OIDC mechanism assues that you are returning to 127.0.0.1:3000, if your requiret to return to a different address or port you need to edid the `lbBaseURL`  variable. 
+
+In the `oAuth2Endpoints` include the display text you want to see on the Login button and the suffix of the authURL which is `api/v3/auth/oidc` (the preffix is set as the `lbBaseURL`).
+

--- a/Development/v4.x/configuration.md
+++ b/Development/v4.x/configuration.md
@@ -15,7 +15,7 @@ The configuration file can be served from the backend, via the `admin/client/con
 An example is shown below
 
 ```
-frontend/src/assets/config.json:
+frontend.config.json:
 
 {
   "accessTokenPrefix": "",  // Set the backend token prefix. Should be empty string for current backend or "Bearer " if using scicat-backend-next.

--- a/Development/v4.x/configuration.md
+++ b/Development/v4.x/configuration.md
@@ -7,7 +7,10 @@
 
 ## SciCat Frontend
 
-This is the configuration file for the frontend client. The configuration file allows the systems administrator to configure every aspect of the client including switching on/off almost all non essential features. The configuration file can either be served from the backend, via the `/client/config.json` endpoint or mounted into `/usr/share/nginx/html/assets/config.json`.
+This is the configuration file for the frontend client. The configuration file allows the systems administrator to configure every aspect of the client including switching on/off almost all non essential features. 
+
+The configuration file can be served from the backend, via the `admin/client/config.json` endpoint. The frontend would expect the backend to be served on port 3000 in a routing configuration for this  to work.  The configuration file can also be mounted to the volume `/home/node/app/dist/config/frontend.config.json` for it to be served through this endpoint. 
+
 
 An example is shown below
 
@@ -138,44 +141,179 @@ frontend/src/assets/config.json:
 
 This is the configuration file for the backend. This file allows the systems administrator to configure connected services, like authentication services and message queues, and also switching on/off almost all non essential features. The configuration file is a [dotenv](https://www.npmjs.com/package/dotenv) file and is read by the backend at runtime.
 
-An example is shown below
+There are currently many configurable additions to SciCat which makes it very flexible these are:
+- OIDC for authenticatoin
+- LDAP for authentication
+- Elastic Search 
+- SMTP for sending emails to notify users of SciCat jobs
+- AMQP to provide a message queue for the jobs 
+
+An minimal example is shown below followed by a full example:
+
+#### Minimal Backend Config Example
+```
+   ADMIN_GROUPS [string] Optional Comma separated list of admin groups with admin permission assigned to the listed users. Example: "admin, ingestor". For more details check: Scicat Documentation
+
+   EXPRESS_SESSION_SECRET [string] Optional Secret used to set up express session.
+
+   HTTP_MAX_REDIRECTS [number] Optional Max redirects for http requests. Defaults to 5.
+
+   HTTP_TIMEOUT [number] Optional Timeout from http requests in ms. Defaults to 5000.
+
+   JWT_SECRET [string] The secret for your JWT token, used for authorization.
+
+   JWT_EXPIRES_IN [number] Optional How long, in seconds, the JWT token is valid. Defaults to 3600.
+
+   MONGODB_URI [string] The URI for your MongoDB instance.
+
+```
+
+
+#### Full Backend Config Example
 
 ```
 backend/.env
 
-DOI_PREFIX="<DOI_PREFIX>"  // The facility DOI prefix, with trailing slash.
-EXPRESS_SESSION_SECRET="<EXPRESS_SESSION_SECRET>"  // *Optional* Secret used to set up express session.
-HTTP_MAX_REDIRECTS=5  // *Optional* Max redirects for http requests. Defaults to 5.
-HTTP_TIMEOUT=5000  // *Optional* Timeout from http requests in ms. Defaults to 5000.
-JWT_SECRET=<JWT_SECRET>  // The secret for your JWT token, used for authorization.
-JWT_EXPIRES_IN=3600  // *Optional*  How long, in seconds, the JWT token is valid. Defaults to `3600`.
-LDAP_URL="ldaps://ldap.server.com:636/"  // *Optional* The URL (and port) to your LDAP server.
-LDAP_BIND_DN="<USERNAME>@server.com"  // *Optional* Bind_DN for your LDAP server.
-LDAP_BIND_CREDENTIALS=<PASSWORD>  // *Optional* Credentials for your LDAP server.
-LDAP_SEARCH_BASE=<SEARCH_BASE>  // *Optional* Search base for your LDAP server.
-LDAP_SEARCH_FILTER="(LDAPUsername={{username}})"  // *Optional* Search filter for you LDAP server.
-LOGBOOK_ENABLED=<"yes"|"no">  // *Optional* Flag to enable/disable the Logbook endpoints. Values "yes" or "no". Defaults to "no".
-LOGBOOK_BASE_URL="http://localhost:3030/scichatapi"  // *Optional* The base URL to the SciChat wrapper API. Only required if Logbook is enabled.
-LOGBOOK_USERNAME="<LOGBOOK_USERNAME>"  // *Optional* The username used to authenticate to the SciChat wrapper API. Only required if Logbook is enabled.
-LOGBOOK_PASSWORD="<LOGBOOK_PASSWORD>"  // *Optional* The password used to authenticate to the SciChat wrapper API. Only required if Logbook is enabled.
-METADATA_KEYS_RETURN_LIMIT=100  // *Optional* The return limit for the `/Datasets/metadataKeys` endpoint.
-METADATA_PARENT_INSTANCES_RETURN_LIMIT=100  // *Optional* The return limit of Datasets to extract metadata keys from for the `/Datasets/metadataKeys` endpoint.
-MONGODB_URI="mongodb://<USERNAME>:<PASSWORD>@<HOST>:27017/<DB_NAME>"  // The URI for your MongoDB instance.
-OAI_PROVIDER_ROUTE="<OAI_PROVIDER_ROUTE>"  // *Optional* URI to OAI provider, used for the `/publisheddata/:id/resync` endpoint.
-PID_PREFIX="<PID_PREFIX>"  // The facility PID prefix, with trailing slash.
-PUBLIC_URL_PREFIX="https://doi.ess.eu/detail/"  // The base URL to the facility Landing Page.
-PORT=3000  // *Optional* The port on which you want to access the app. Defaults to `3000`.
-RABBITMQ_ENABLED=<"yes"|"no">  *Optional* Flag to enable/disable RabbitMQ consumer. Values "yes" or "no". Defaults to "no".
-RABBITMQ_HOSTNAME="localhost"  // *Optional* The hostname of the RabbitMQ message broker. Only required if RabbitMQ is enabled.
-RABBITMQ_USERNAME="rabbitmq"  // *Optional* The username used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled.
-RABBITMQ_PASSWORD="rabbitmq"  // *Optional* The password used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled.
-REGISTER_DOI_URI="https://mds.test.datacite.org/doi"  // URI to the organization that registers the facilities DOIs.
-REGISTER_METADATA_URI="https://mds.test.datacite.org/metadata"  // URI to the organization that registers the facilities published data metadata.
-SITE=<SITE>  // The name of your site.
-SMTP_HOST=<SMTP_HOST>  // Host of SMTP server.
-SMTP_MESSAGE_FROM=<SMTP_MESSAGE_FROM>  // Email address that emails should be sent from.
-SMTP_PORT=<SMTP_PORT>  // Port of SMTP server.
-SMTP_SECURE=<SMTP_SECURE>  // Secure of SMTP server.
+Valid environment variables for the .env file. See .env.example for examples value formats.
+
+## Data Management
+
+    ADMIN_GROUPS [string] Optional Comma separated list of admin groups with admin permission assigned to the listed users. Example: "admin, ingestor". For more details check: Scicat Documentation
+
+    CREATE_DATASET_GROUPS [string] Optional Comma seperated list of create dataset groups. Users belong to the listed groups can create dataset with/without PID. Example: "group1, group2". For more details check: Scicat Documentation
+
+    CREATE_DATASET_WITH_PID_GROUPS [string] Optional Comma seperated list of create dataset with pid groups. Users belong to the listed groups can create dataset with PID. Example: "group1, group2". For more details check: Scicat Documentation
+
+    DELETE_GROUPS [string] Optional Comma seperated list of delete groups. Users belong to the listed groups can delete any dataset, origDatablocks, datablocks etc. For more details check: Scicat Documentation
+
+    DATASET_CREATION_VALIDATION_ENABLED [boolean] Flag to enable/disable dataset validation to validate if requested new dataset is valid with given regular expression. Preconfigure DATASET_CREATION_VALIDATION_REGEX variable is required. Default value: false
+
+    DATASET_CREATION_VALIDATION_REGEX [string] Regular expression validation for new dataset request. Default value: ""
+
+    PROPOSAL_GROUPS [string] Optional Comma separated list of proposal groups with permission to create any proposals. Example: "proposaladmin, proposalingestor". For more details check: Scicat Documentation
+
+    SAMPLE_GROUPS [string] Optional Comma separated list of sample groups with permission to create any samples. Example: "sampleadmin, sampleingestor". For more details check: Scicat Documentation
+    
+## Access groups from external administration systems
+
+    ACCESS_GROUPS_STATIC_VALUES [string] Optional Comma separated list of access groups automatically assigned to all users. Example: "scicat, user"
+
+    ACCESS_GROUPS_SERVICE_TOKEN [string] Optional Authentication token used if access groups are obtained from a third party service. This value is not used by the vanilla installation, but only if the instance is customized to use an external service to provide user groups, like the ESS example
+
+    ACCESS_GROUP_SERVICE_API_URL [string] Optional URL of the service providing the users' access groups. This value is not used by the vanilla installation, but only if the instance is customized to use an external service to provide user groups, like the ESS example
+   
+## Secrets, tokens and http settings
+
+    EXPRESS_SESSION_SECRET [string] Optional Secret used to set up express session.
+
+    HTTP_MAX_REDIRECTS [number] Optional Max redirects for http requests. Defaults to 5.
+
+    HTTP_TIMEOUT [number] Optional Timeout from http requests in ms. Defaults to 5000.
+
+    JWT_SECRET [string] The secret for your JWT token, used for authorization.
+
+    JWT_EXPIRES_IN [number] Optional How long, in seconds, the JWT token is valid. Defaults to 3600.
+
+## LDAP Settings - only required for authentication using LDAP
+
+    LDAP_URL [string] Optional The URL to your LDAP server.
+
+    LDAP_BIND_DN [string] Optional Bind_DN for your LDAP server.
+
+    LDAP_BIND_CREDENTIALS [string] Optional Credentials for your LDAP server.
+
+    LDAP_SEARCH_BASE [string] Optional Search base for your LDAP server.
+
+    LDAP_SEARCH_FILTER [string] Optional Search filter for you LDAP server.
+
+## OIDC Settings - only required for OIDC authentication
+
+    OIDC_ISSUER [string] Optional URL of the oidc server providing the authentication service. Example: https://identity.esss.dk/realm/ess.
+
+    OIDC_CLIENT_ID [string] Optional Identity of the client that we want to use to obtain the user token. Example: scicat
+
+    OIDC_CLIENT_SECRET [string] Optional Secret to provide to the oidc service to obtain the user token. Example: Aa1JIw3kv3mQlGFWhRrE3gOdkH6xreAwro
+
+    OIDC_CALLBACK_URL [string] Optional SciCat callback URL that we want th eoidc service to redirect to, in case of successful login. Example: http://myscicat/api/v3/oidc/callback
+
+    OIDC_SCOPE [string] Optional Space separated list of the info returned by the oidc service. Example: "openid profile email"
+
+    OIDC_SUCCESS_URL [string] Optional SciCat Frontend auth-callback URL. Required in order to pass user credentials to SciCat Frontend after OIDC login. Example: https://myscicatfrontend/auth-callback
+
+    OIDC_ACCESS_GROUPS [string] Optional Functionality is still unclear.
+
+## Scicat metadata settings
+
+    PID_PREFIX [string] The facility PID prefix, with trailing slash.
+
+    LOGBOOK_ENABLED [string] Optional Flag to enable/disable the Logbook endpoints. Values "yes" or "no". Defaults to "no".
+
+    LOGBOOK_BASE_URL [string] Optional The base URL to the Logbook API. Only required if Logbook is enabled.
+
+    METADATA_KEYS_RETURN_LIMIT [number] Optional The return limit for the /Datasets/metadataKeys endpoint.
+
+    METADATA_PARENT_INSTANCES_RETURN_LIMIT Optional The return limit of Datasets to extract metadata keys from for the /Datasets/metadataKeys endpoint.
+
+    MONGODB_URI [string] The URI for your MongoDB instance.
+
+    SITE [string] The name of your site.
+
+    POLICY_PUBLICATION_SHIFT [integer] Optional Embargo period expressed in years. Default value: 3 years
+
+    POLICY_RETENTION_SHIFT [integer] Optional Retention period (aka how long the facility will hold on to data) expressed in years. Default value: -1 (data will be hold indefinitely)
+
+## Settings for publishing data sets
+
+    OAI_PROVIDER_ROUTE [string] Optional URI to OAI provider, used for the /publisheddata/:id/resync endpoint.
+
+    DOI_PREFIX [string] The facility DOI prefix, with trailing slash.
+
+    PUBLIC_URL_PREFIX [string] The base URL to the facility Landing Page.
+
+    PORT [number] Optional The port on which you want to access the app. Defaults to 3000.
+    REGISTER_DOI_URI [string] URI to the organization that registers the facilities DOI's.
+
+    REGISTER_METADATA_URI [string] URI to the organization that registers the facilities published data metadata.
+
+## Message queue settings - only required when using the jobs settings. This currently does not work in release 4.4 but will be released soon 
+<!-- 
+    RABBITMQ_ENABLED [string] Optional Flag to enable/disable RabbitMQ consumer. Values "yes" or "no". Defaults to "no".
+
+    RABBITMQ_HOSTNAME [string] Optional The hostname of the RabbitMQ message broker. Only required if RabbitMQ is enabled.
+
+    RABBITMQ_USERNAME [string] Optional The username used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled.
+
+    RABBITMQ_PASSWORD [string] Optional The password used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled. -->
+
+## SMTP Settings - need this option if you require Scicat to send emails.     
+
+    SMTP_HOST [string] Optional Host of SMTP server.
+
+    SMTP_MESSAGE_FROM [string] Optional Email address that emails should be sent from.
+
+    SMTP_PORT [string] Optional Port of SMTP server.
+
+    SMTP_SECURE [string] Optional Secure of SMTP server.
+    
+
+## Elastic Search settings - use these to enable elastic search 
+
+    ELASTICSEARCH_ENABLED [string] Flag to enable/disable the Elasticsearch endpoints. Values "yes" or "no". Defaults to "no"
+
+    ES_HOST [string] Host of Elasticsearch server instance
+
+    ES_USERNAME [string] Optional Elasticsearch username that can be customized when loads Elasticsearch server. Default value: 'elastic'
+
+    ES_PASSWORD [string] Elasticsearch password that can be customized when loads Elasticsearch server.
+
+    MONGODB_COLLECTION [string] Collection name to be mapped into specified Elasticsearch index. Used for data synchronization between mongoDB and Elasticsearch index.
+
+    ES_MAX_RESULT [number] Maximum records can be indexed into Elasticsearch. Default value: 10000
+
+    ES_FIELDS_LIMIT [number] The total number of fields in an index. Default value: 1000
+
+    ES_REFRESH [string] If set to wait_for Elasticsearch will wait till data is insereted to specificied index then return response. Unless you have a good reason to wait for the change to become visible, always use false (the default setting).
+
 
 ```
 


### PR DESCRIPTION
* A small tweak to the documentation on how to set up the OIDC in SciCat. 
* Addition how to server the frontend.config.json through the backend 